### PR TITLE
Add market slug and validation features

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -13,5 +13,17 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
+  pgadmin:
+    image: dpage/pgadmin4
+    container_name: mercadin_pgadmin
+    restart: always
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@admin.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+    ports:
+      - "5050:80"
+    depends_on:
+      - postgres
+
 volumes:
   postgres_data:

--- a/server/package.json
+++ b/server/package.json
@@ -9,6 +9,7 @@
     "prisma:migrate": "prisma migrate dev",
     "prisma:migrate:reset": "prisma migrate reset",
     "prisma:push": "prisma db push",
+    "prisma:reset": "pnpm prisma db push --force-reset && pnpm prisma migrate reset",
     "format": "prettier --write \"src/**/*.ts\"",
     "start": "node dist/main.js",
     "dev": "nest start --watch",

--- a/server/prisma/migrations/20260422035557/migration.sql
+++ b/server/prisma/migrations/20260422035557/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[slug]` on the table `Market` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `slug` to the `Market` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Market" ADD COLUMN     "slug" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Market_slug_key" ON "Market"("slug");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -31,6 +31,7 @@ model User {
 // -----------------------------------------------------------------------------
 model Market {
   id        String    @id @default(uuid())
+  slug      String    @unique // Identificador usado na API (ex: MARKET_SLUGS enum)
   name      String    @unique // Ex: "Savegnago", "Tenda Atacado", "Jaú Serve"
   url       String?   // URL base do supermercado
   

--- a/server/src/common/constants/market-slugs.constant.ts
+++ b/server/src/common/constants/market-slugs.constant.ts
@@ -1,0 +1,3 @@
+export enum MARKET_SLUGS {
+  JAU_SERVE = "JAU_SERVE",
+}

--- a/server/src/common/pipes/parse-market-slug.pipe.ts
+++ b/server/src/common/pipes/parse-market-slug.pipe.ts
@@ -1,0 +1,32 @@
+import {
+  ArgumentMetadata,
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+  PipeTransform,
+} from "@nestjs/common";
+import { MARKET_SLUGS } from "../constants/market-slugs.constant";
+import { MarketsRepository } from "@/modules/markets/repositories/markets.repository";
+
+@Injectable()
+export class ParseMarketSlugPipe implements PipeTransform<string | undefined, Promise<string | undefined>> {
+  constructor(private readonly marketsRepo: MarketsRepository) {}
+
+  async transform(value: string | undefined, metadata: ArgumentMetadata): Promise<string | undefined> {
+    if (!value) {
+      return value;
+    }
+
+    const validSlugs = Object.values(MARKET_SLUGS) as string[];
+    if (!validSlugs.includes(value)) {
+      throw new BadRequestException(`Invalid market: ${value}`);
+    }
+
+    const market = await this.marketsRepo.findBySlug(value);
+    if (!market) {
+      throw new NotFoundException(`Market with slug '${value}' not found in database.`);
+    }
+
+    return value;
+  }
+}

--- a/server/src/modules/markets/repositories/markets.repository.ts
+++ b/server/src/modules/markets/repositories/markets.repository.ts
@@ -13,10 +13,14 @@ export class MarketsRepository {
     return this.prisma.market.findUnique({ where: { name } });
   }
 
-  upsertByName(data: { name: string; url?: string }) {
+  findBySlug(slug: string) {
+    return this.prisma.market.findUnique({ where: { slug } });
+  }
+
+  upsertBySlug(data: { name: string; url: string; slug: string }) {
     return this.prisma.market.upsert({
-      where: { name: data.name },
-      create: { name: data.name, url: data.url },
+      where: { slug: data.slug },
+      create: { name: data.name, url: data.url, slug: data.slug },
       update: { url: data.url },
     });
   }

--- a/server/src/modules/products/controllers/products.controller.ts
+++ b/server/src/modules/products/controllers/products.controller.ts
@@ -2,6 +2,8 @@ import { Controller, Get, Query } from "@nestjs/common";
 import { ProductsService } from "../services/products.service";
 import { SearchProductsDto } from "../dtos/search-products.dto";
 import { Public } from "@/common/decorators/public.decorator";
+import { ParseMarketSlugPipe } from "@/common/pipes/parse-market-slug.pipe";
+import { MARKET_SLUGS } from "@/common/constants/market-slugs.constant";
 
 @Controller("products")
 export class ProductsController {
@@ -9,8 +11,11 @@ export class ProductsController {
 
   @Public()
   @Get("search")
-  search(@Query() dto: SearchProductsDto) {
-    return this.products.search(dto.q, dto.market);
+  search(
+    @Query() dto: SearchProductsDto,
+    @Query("market", ParseMarketSlugPipe) marketSlug?: MARKET_SLUGS,
+  ) {
+    return this.products.search(dto.q, marketSlug);
   }
 
   @Public()

--- a/server/src/modules/products/dtos/search-products.dto.ts
+++ b/server/src/modules/products/dtos/search-products.dto.ts
@@ -1,4 +1,5 @@
-import { IsOptional, IsString, MinLength } from "class-validator";
+import { IsEnum, IsOptional, IsString, MinLength } from "class-validator";
+import { MARKET_SLUGS } from "@/common/constants/market-slugs.constant";
 
 export class SearchProductsDto {
   @IsString()
@@ -6,6 +7,6 @@ export class SearchProductsDto {
   q!: string;
 
   @IsOptional()
-  @IsString()
-  market?: string;
+  @IsEnum(MARKET_SLUGS)
+  market?: MARKET_SLUGS;
 }

--- a/server/src/modules/products/services/product-ingest.service.ts
+++ b/server/src/modules/products/services/product-ingest.service.ts
@@ -13,9 +13,10 @@ export class ProductIngestService {
   ) {}
 
   async ingest(batch: ScrapedBatch): Promise<void> {
-    const market = await this.markets.upsertByName({
+    const market = await this.markets.upsertBySlug({
       name: batch.marketName,
       url: batch.marketUrl,
+      slug: batch.marketSlug,
     });
 
     for (const product of batch.products) {

--- a/server/src/modules/products/services/products.service.ts
+++ b/server/src/modules/products/services/products.service.ts
@@ -13,7 +13,7 @@ export class ProductsService {
 
   async search(query: string, marketSlug?: string) {
     const marketName = marketSlug
-      ? this.orchestrator.findScraper(marketSlug)?.marketName
+      ? this.orchestrator.findScraper(marketSlug)!.marketName
       : undefined;
 
     const cached = await this.repo.findFreshByQuery({ q: query, marketName });

--- a/server/src/modules/scraping/scrapers/jauserve.scraper.ts
+++ b/server/src/modules/scraping/scrapers/jauserve.scraper.ts
@@ -8,9 +8,11 @@ const SEARCH_PATH = "/on/demandware.store/Sites-JauServe-Site/pt_BR/Search-Show"
 const USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
 
+import { MARKET_SLUGS } from "@/common/constants/market-slugs.constant";
+
 @Injectable()
 export class JauserveScraper implements IMarketScraper {
-  readonly marketSlug = "jauserve";
+  readonly marketSlug = MARKET_SLUGS.JAU_SERVE;
   readonly marketName = "Jaú Serve";
   readonly marketUrl = BASE_URL;
 


### PR DESCRIPTION
This pull request introduces a new, stricter way to identify markets using unique slugs, enforces slug-based validation throughout the API, and adds developer tooling improvements. The main changes include updating the database schema to require unique market slugs, refactoring code to use these slugs, and adding validation and parsing logic for slugs in API endpoints.

Closes #5 

**Database and Model Changes:**

- Added a required, unique `slug` field to the `Market` table in the Prisma schema and database, ensuring every market has a unique identifier for API usage. (`server/prisma/schema.prisma`, `server/prisma/migrations/20260422035557/migration.sql`) [[1]](diffhunk://#diff-f15e3ac1b46f7ac4b6b782547e2ca4d45a886d518c81302a82eab7164c514cf2R34) [[2]](diffhunk://#diff-1de6d3b4e99b948409f43a32b1afe19bfed23e32f6fb5ea1911b6df638794747R1-R12)

**API Input Validation and Parsing:**

- Introduced the `MARKET_SLUGS` enum and a new `ParseMarketSlugPipe` to validate and check the existence of market slugs in incoming API requests. (`server/src/common/constants/market-slugs.constant.ts`, `server/src/common/pipes/parse-market-slug.pipe.ts`) [[1]](diffhunk://#diff-3089fff3c8b6ac41ee307ca266dc29b1606b0600e7e598e8edb03728cb9221bdR1-R3) [[2]](diffhunk://#diff-ced5f392f3459843b6aa51e8f6710070ac018ee73afd849d67d3bb388daa46f6R1-R32)
- Updated the `SearchProductsDto` to use the `MARKET_SLUGS` enum for the `market` field, ensuring only valid slugs are accepted. (`server/src/modules/products/dtos/search-products.dto.ts`)
- Modified the `ProductsController` to use the new pipe and enum for the `market` query parameter in the search endpoint. (`server/src/modules/products/controllers/products.controller.ts`)

**Repository and Service Refactoring:**

- Refactored the `MarketsRepository` to add `findBySlug` and `upsertBySlug` methods, replacing previous name-based operations with slug-based ones. (`server/src/modules/markets/repositories/markets.repository.ts`)
- Updated services to use slugs for market identification and lookup, including ingestion and search logic. [[1]](diffhunk://#diff-c88a901dd70d5ffe24b14d9dbef563a0119b014c207bc8bd9a5767813d30d30bL16-R19) [[2]](diffhunk://#diff-7c0df8f9b70d0b1909d9bb81d14bbb08b17190a8ae04c75cfc8d3779a930da01L16-R16) [[3]](diffhunk://#diff-ceb13039f068bea177a4898f8932b20aa29d3bbb1614ca31a32b7c466b321108R11-R15)