### PR TITLE
Fix validation for items savings

### DIFF
--- a/server/src/modules/shopping-lists/services/price-combination.service.ts
+++ b/server/src/modules/shopping-lists/services/price-combination.service.ts
@@ -40,6 +40,14 @@ export interface SuperCartPick {
   marketName: string;
 }
 
+export interface SuperCart {
+  total: number;
+  marketsCount: number;
+  isComplete: boolean;
+  picks: SuperCartPick[];
+  missing: string[];
+}
+
 @Injectable()
 export class PriceCombinationService {
   constructor(private readonly repo: ShoppingListsRepository) {}
@@ -60,9 +68,10 @@ export class PriceCombinationService {
       undefined,
     );
 
-    const savings = cheapestSingleMarket
-      ? Number((cheapestSingleMarket.total - superCart.total).toFixed(2))
-      : null;
+    const savings =
+      cheapestSingleMarket && superCart.isComplete
+        ? Number((cheapestSingleMarket.total - superCart.total).toFixed(2))
+        : null;
 
     return {
       listId,
@@ -142,7 +151,7 @@ export class PriceCombinationService {
     });
   }
 
-  private buildSuperCart(items: AggregatedItem[]) {
+  private buildSuperCart(items: AggregatedItem[]): SuperCart {
     const picks: SuperCartPick[] = [];
     const missing: string[] = [];
     let total = 0;
@@ -171,6 +180,7 @@ export class PriceCombinationService {
     return {
       total: Number(total.toFixed(2)),
       marketsCount: marketsUsed.size,
+      isComplete: missing.length === 0,
       picks,
       missing,
     };


### PR DESCRIPTION
This pull request introduces a new `SuperCart` interface and improves how super cart results are structured and returned in the `PriceCombinationService`. The main focus is on making the data returned from the service more explicit, complete, and easier to use by consumers.

Closes #4 

### Data Model Enhancements

* Added a new `SuperCart` interface to clearly define the structure of the aggregated cart, including `total`, `marketsCount`, `isComplete`, `picks`, and `missing` fields.
* Updated the `buildSuperCart` method to return a typed `SuperCart` object, improving type safety and clarity.
* Added the `isComplete` field to the returned super cart, which indicates whether all items are present (i.e., nothing missing).

### Business Logic Improvements

* Modified the savings calculation to only compute savings if both a cheapest single market exists and the super cart is complete, preventing misleading or incorrect savings values.